### PR TITLE
Fix already new hash syntax broke

### DIFF
--- a/lib/synvert/snippets/ruby/new_hash_syntax.rb
+++ b/lib/synvert/snippets/ruby/new_hash_syntax.rb
@@ -11,7 +11,7 @@ Use ruby new hash syntax.
       within_node type: 'hash' do
         with_node type: 'pair' do
           if :sym == node.key.type
-            new_key = node.key.source(self)[1..-1]
+            new_key = node.key.source(self)[/:?(.*)/, 1]
             replace_with "#{new_key}: {{value}}"
           end
         end

--- a/spec/synvert/snippets/ruby/new_hash_syntax_spec.rb
+++ b/spec/synvert/snippets/ruby/new_hash_syntax_spec.rb
@@ -12,10 +12,12 @@ describe 'Ruby uses new hash synax' do
     let(:test_content) {"""
 {:foo => 'bar', 'foo' => 'bar'}
 {:key1 => 'value1', :key2 => 'value2'}
+{foo_key: 'foo_value', bar_key: 42}
     """}
     let(:test_rewritten_content) {"""
 {foo: 'bar', 'foo' => 'bar'}
 {key1: 'value1', key2: 'value2'}
+{foo_key: 'foo_value', bar_key: 42}
     """}
 
     it 'process' do


### PR DESCRIPTION
`-r ruby_new_hash_syntax` broke new hash syntax e.g. `{foo: "bar"} # => {oo: "bar"}`
