### PR TITLE
Fixes the outdated usage example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $ synvert --sync
 ```
 
 ```
-$ synvert -r factory_girl_short_syntax,upgrade_rails_3_2_to_4_0 ~/Sites/railsbp/rails-bestpractices.com
+$ synvert -r factory_girl/use_short_syntax,rails/upgrade_3_2_to_4_0 ~/Sites/railsbp/rails-bestpractices.com
 ```
 
 ## Documentation


### PR DESCRIPTION
Also, I suggest changing the installation example to read something like:

`$ gem install synvert && synvert --sync`

Since it won't work without running `synvert --sync` the first time.
